### PR TITLE
Accepts set_status without a message

### DIFF
--- a/lib/hatch_tracing.ex
+++ b/lib/hatch_tracing.ex
@@ -253,19 +253,16 @@ defmodule HatchTracing do
   Reference:
   https://opentelemetry.io/docs/reference/specification/trace/api/#set-status
   """
-  @spec set_status(OpenTelemetry.status()) :: boolean()
-  defdelegate set_status(status), to: OpenTelemetry.Tracer
+  @spec set_status(OpenTelemetry.status() | OpenTelemetry.status_code(), String.t()) :: boolean()
+  def set_status(status_or_status_code, description \\ "")
 
-  @doc """
-  Creates and sets the Status of the currently active Span.
+  def set_status(status, _description) when is_tuple(status) do
+    OpenTelemetry.Tracer.set_status(status)
+  end
 
-  If used, this will override the default Span Status, which is `:unset`.
-
-  Reference:
-  https://opentelemetry.io/docs/reference/specification/trace/api/#set-status
-  """
-  @spec set_status(OpenTelemetry.status_code(), String.t()) :: boolean
-  defdelegate set_status(status, message), to: OpenTelemetry.Tracer
+  def set_status(status_code, description) do
+    OpenTelemetry.Tracer.set_status(status_code, description)
+  end
 
   # @doc """
   # Creates a new span which is set to the currently active Span in the Context of


### PR DESCRIPTION
OpenTelemetry declares two functions:

```elixir
OpenTelemetry.set_status(status)
OpenTelemetry.set_status(status_code, message)
```

`status` and `status_code` are different structures.

* `status_code` is either `:ok` or `:error` or `:unset`
* `status` is a tuple `{:status, status_code(), String.t()}`

If we follow this way, we cannot do `.set_status(:ok)`, we would need to do `.set_status(:ok, "")`.

In order to avoid that change, I'm changing these functions to allow the following options:

```elixir
HatchTracing.set_status(status)
HatchTracing.set_status(status_code)
HatchTracing.set_status(status_code, message)
```