### PR TITLE
Bump to 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## v0.1.2
 
 - Bump dependencies version
+  - opentelemetry_exporter from 1.6.0 to 1.7.0
+  - ex_doc from 0.30.1 to 0.31.2
+  - mix_audit from 2.1.1 to 2.1.3
+  - new_relic_agent from 1.27.8 to 1.29.0
+  - credo from 1.7.0 to 1.7.5
+  - sobelow from 0.12.2 to 0.13.0
+  - actions/cache from 3 to 4
 
 ## v0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for `hatch_tracing`
 
+## v0.1.2
+
+- Bump dependencies version
+
 ## v0.1.1
 
 - Fix some type specs to match the expected by OpenTelemetry #6

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule HatchTracing.MixProject do
   use Mix.Project
 
-  @version "0.1.1"
+  @version "0.1.2"
   @source_url "https://github.com/Hatch1fy/hatch-tracing"
 
   def project do


### PR DESCRIPTION
This is upgrading the library to the new version so the dependency updates happening in the library can be fetched in the projects that are using the library.