### PR TITLE
Fix with_span start_opts type check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for `hatch_tracing`
 
+## v0.1.3
+
+- Fix type check warnings when calling the `with_span` function.
+
 ## v0.1.2
 
 - Bump dependencies version

--- a/lib/hatch_tracing.ex
+++ b/lib/hatch_tracing.ex
@@ -100,7 +100,7 @@ defmodule HatchTracing do
       |> :opentelemetry.get_application_tracer()
       |> :otel_tracer.with_span(
         unquote(name),
-        unquote(start_opts),
+        Map.new(unquote(start_opts)),
         fn ctx ->
           try do
             unquote(block)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule HatchTracing.MixProject do
   use Mix.Project
 
-  @version "0.1.2"
+  @version "0.1.3"
   @source_url "https://github.com/Hatch1fy/hatch-tracing"
 
   def project do


### PR DESCRIPTION
Fix the error that Hatch Elixir has been complaining about the types when calling the with_span function.

```elixir
The call otel_tracer:with_span
         ({atom(), _},
          <<84,121,112,101,84,101,115,116,46,99,97,108,108,47,48>>,
          #{},
          fun((_) -> 'ok')) breaks the contract 
          (opentelemetry:tracer(),
          opentelemetry:span_name(),
          otel_span:start_opts(),
          traced_fun(T)) ->
             TElixirLS Dialyzer
```

Looking into the OpenTelemetry Tracer implementation. We should call the map new function to avoid breaking the type contract.
```elixir
quote do
      :otel_tracer.with_span(
        :opentelemetry.get_application_tracer(__MODULE__),
        unquote(name),
        Map.new(unquote(start_opts)),
        fn _ -> unquote(block) end
      )
    end
```